### PR TITLE
Add RestlessAgents to the deployment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Once you're comfortable with the basics, explore the full list below. Every reso
 - **[beta]** [hermes-agent-template](https://github.com/Crustocean/hermes-agent-template) by [Crustocean](https://github.com/Crustocean) — Production-ready Docker image for cloud Hermes deployments. Infrastructure wiring pre-configured.
 - **[experimental]** [portainer-stack-hermes](https://github.com/ellickjohnson/portainer-stack-hermes) by [ellickjohnson](https://github.com/ellickjohnson) — Docker Compose + Portainer + ttyd web terminal. Deploy Hermes and reach it from any browser.
 - **[experimental]** [hermes-autonomous-server](https://github.com/JackTheGit/hermes-autonomous-server) by [JackTheGit](https://github.com/JackTheGit) — Headless Hermes deployment with systemd and cron on Linux servers. Runs unattended.
+- **[beta]** [RestlessAgents](https://restlessagents.com/) by [Tom Oehlrich](https://github.com/tomoehlrich) — Comparison directory for managed and self-hosted VPS hosting options across OpenClaw and Hermes Agent.
 - **[beta]** [evey-setup](https://github.com/42-evey/evey-setup) by [42-evey](https://github.com/42-evey) — One-command bootstrap from a fresh clone to a working multi-platform Hermes deployment: free models, 29 plugins pre-wired, gateway configured. Not a fork — an opinionated setup script.
 
 <br>


### PR DESCRIPTION
Adds RestlessAgents.com to the Deployment section under Tools & Utilities.

RestlessAgents is a comparison directory covering managed and self-hosted VPS hosting options for OpenClaw and Hermes Agent. I built and maintain this site, sharing for visibility to anyone comparing hosting options for Hermes deployments. Tagged as [beta].